### PR TITLE
Fix Node.js v20.9.0 compatibility: replace import.meta.dirname with _…

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
@@ -18,14 +21,14 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(__dirname, "client", "src"),
+      "@shared": path.resolve(__dirname, "shared"),
+      "@assets": path.resolve(__dirname, "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
+  root: path.resolve(__dirname, "client"),
   build: {
-    outDir: path.resolve(import.meta.dirname, "dist/public"),
+    outDir: path.resolve(__dirname, "dist/public"),
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
…_dirname

- Replace import.meta.dirname with path.dirname(fileURLToPath(import.meta.url))
- Add fileURLToPath import from 'url' module
- Fixes TypeError [ERR_INVALID_ARG_TYPE] in vite.config.ts line 21
- Compatible with Node.js v20.9.0 (import.meta.dirname requires v20.11.0+)